### PR TITLE
fix react-error-overlay dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
+  },
   "eslintConfig": {
     "extends": "react-app"
   },
@@ -56,5 +59,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "react-error-overlay": "^6.0.9"
   }
 }


### PR DESCRIPTION
Fix Process Error, which didn't allow us to do hot reload.

<img width="678" alt="Captura de Pantalla 2022-03-25 a la(s) 16 59 46" src="https://user-images.githubusercontent.com/89902573/160192780-57b9ab17-19c7-4c89-b1da-1280165f6a74.png">

