### PR TITLE
Feature/ot162 110

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,10 +28,9 @@ import Contact from "./Components/Contact/Contact";
 import MembersList from "./Components/Members/MembersList";
 import UserList from "./Components/Users/UserList/UserList";
 import NewsSection from "./Components/News/NewsSection";
-import BackofficeMembersList from './Components/Members/BackofficeMembersList';
-import News from './Components/News/News';
-import SiteDataForm from './Components/SiteDataForm/SiteDataForm'
 import BackofficeMembersList from "./Components/Members/BackofficeMembersList";
+import News from "./Components/News/News";
+import SiteDataForm from "./Components/SiteDataForm/SiteDataForm";
 import {
   GetNews,
   GetSingleNews,

--- a/src/Components/Slides/SlidesList.js
+++ b/src/Components/Slides/SlidesList.js
@@ -11,12 +11,22 @@ import {
   Stack,
 } from "@mui/material";
 import axios from "axios";
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import swal from "sweetalert";
+import { getSlides } from "../../features/slide/slideSlice";
 
 const slideURL = "https://ongapi.alkemy.org/api/slide";
 
 const SlidesList = () => {
+  const dispatch = useDispatch();
+  const slides = useSelector((state) => state.slide.list);
+
+  useEffect(() => {
+    dispatch(getSlides());
+  }, [dispatch]);
+
   const slidesMock = [
     {
       id: 1,
@@ -93,7 +103,7 @@ const SlidesList = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {slidesMock.map((slide) => (
+            {slides.map((slide) => (
               <TableRow
                 key={slide.id}
                 sx={{ "&:last-child td, &:last-child th": { border: 0 } }}

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,8 +1,10 @@
-import { configureStore } from '@reduxjs/toolkit';
-import counterReducer from '../features/counter/counterSlice';
+import { configureStore } from "@reduxjs/toolkit";
+import counterReducer from "../features/counter/counterSlice";
+import slideReducer from "../features/slide/slideSlice";
 
 export default configureStore({
   reducer: {
     counter: counterReducer,
+    slide: slideReducer,
   },
 });

--- a/src/features/slide/slideSlice.js
+++ b/src/features/slide/slideSlice.js
@@ -1,0 +1,30 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { getSlideList } from "../../Services/slideService";
+
+export const getSlides = createAsyncThunk("slide/getSlides", async () => {
+  return getSlideList().then((res) => {
+    return res.data.data;
+  });
+});
+
+const slideSlice = createSlice({
+  name: "slide",
+  initialState: {
+    list: [],
+    status: null,
+  },
+  extraReducers: {
+    [getSlides.pending]: (state, action) => {
+      state.status = "loading";
+    },
+    [getSlides.fulfilled]: (state, { payload }) => {
+      state.list = payload;
+      state.status = "success";
+    },
+    [getSlides.rejected]: (state, action) => {
+      state.status = "failed";
+    },
+  },
+});
+
+export default slideSlice.reducer;


### PR DESCRIPTION
[OT162-110](https://alkemy-labs.atlassian.net/browse/OT162-110)

Criterios de aceptación: Utilizando redux-toolkit, desarrollar un reducer para gestionar el estado de los Slides en el BackOffice. El mismo deberá tener una acción para renderizar el listado de los Slides en BackOffice.

La lógica existente de peticiones a la API deberá moverse a thunks asíncronos dentro del reducer. 

Utilizar el método createAsyncThunk de Redux Toolkit para la creación de thunks: 
https://redux.js.org/tutorials/essentials/part-5-async-logic#writing-async-thunks

Redux States and Actions working:
![simplescreenrecorder-2022-04-07_21 15 23](https://user-images.githubusercontent.com/51249090/162339434-cbde9df0-1f13-4fc2-8e38-5bb9ec2871e3.gif)

Async Thunks added for future implementations:
![image](https://user-images.githubusercontent.com/51249090/162338597-c2fa9037-4ab0-4ae6-8787-efb19d2eb26f.png)

Added in the slideSlice respective for succes case:
![image](https://user-images.githubusercontent.com/51249090/162338729-5432ff58-e4bc-4d31-9b45-b85650c3e8ec.png)

